### PR TITLE
fix: Update `master` to `main` and add concurrency group

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,12 @@ name: Docker Images
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - v*
   pull_request:
     branches:
-    - master
+    - main
   # Run weekly each Sunday at 1:23 UTC
   schedule:
     - cron: '23 1 * * 0'
@@ -103,8 +103,8 @@ jobs:
           -c 'python -m pip list'
 
       - name: Build and publish to registry
-        # every PR will trigger a push event on master, so check the push event is actually coming from master
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'illinois-mla/phys-398-mla-image'
+        # every PR will trigger a push event on main, so check the push event is actually coming from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'illinois-mla/phys-398-mla-image'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     name: Build and publish Docker images

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Docker image for the PHYS 398 MLA used to power the [PrairieLearn workspaces](https://prairielearn.readthedocs.io/en/latest/workspaces/).
 
-[![Docker Images](https://github.com/physicsillinois/phys-398-mla-image/actions/workflows/docker.yml/badge.svg?branch=master)](https://github.com/physicsillinois/phys-398-mla-image/actions/workflows/docker.yml?query=branch%3Amaster)
+[![Docker Images](https://github.com/physicsillinois/phys-398-mla-image/actions/workflows/docker.yml/badge.svg?branch=main)](https://github.com/physicsillinois/phys-398-mla-image/actions/workflows/docker.yml?query=branch%3Amain)
 [![Docker Pulls](https://img.shields.io/docker/pulls/physicsillinois/phys-398-mla)](https://hub.docker.com/r/physicsillinois/phys-398-mla)
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/physicsillinois/phys-398-mla/latest)](https://hub.docker.com/r/physicsillinois/phys-398-mla/tags?name=latest)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ COPY docker/requirements.txt /requirements.txt
 # and /etc/jupyter/jupyter_server_config.py have 8080 and not 8888
 RUN mkdir -p "/home/${NB_USER}/.local" && \
     cp /requirements.txt "/home/${NB_USER}/.local/requirements.txt" && \
-    python -m pip --no-cache-dir install  --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install pip-tools && \
     python -m piptools compile \
         --generate-hashes \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p "/home/${NB_USER}/.local" && \
         --generate-hashes \
         --output-file "/home/${NB_USER}/.local/requirements.lock" \
         "/home/${NB_USER}/.local/requirements.txt" && \
-    python -m pip install --requirement "/home/${NB_USER}/.local/requirements.lock" && \
+    python -m pip --no-cache-dir install --requirement "/home/${NB_USER}/.local/requirements.lock" && \
     conda clean --all -f -y && \
     jupyter lab clean -y && \
     fix-permissions "${CONDA_DIR}" && \


### PR DESCRIPTION
```
* Add concurrency group to cancel jobs still running if new push
* Update use of `master` to `main` for CI and docs
* Use `--no-cache-dir` option for pip install
* Amends PR #1
```