### PR TITLE
feat: Use 'pip-secure-install' recommendations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,15 @@ COPY docker/requirements.txt /requirements.txt
 # Following https://github.com/jupyter/docker-stacks/blob/9b87b16254455fdff2eb7884a424eb19f5aba496/scipy-notebook/Dockerfile
 # PrairieLearn seems to need port 8080 to work, so ensure that both /etc/jupyter/jupyter_notebook_config.py
 # and /etc/jupyter/jupyter_server_config.py have 8080 and not 8888
+#
+# Use Brett Cannon's recommendations for pip-secure-install to ensure environment
+# is reproducible and installed as securely as possible.
+# c.f. https://www.python.org/dev/peps/pep-0665/#secure-by-design
+# c.f. https://github.com/brettcannon/pip-secure-install
+# c.f. https://twitter.com/brettsky/status/1486137764315688961
+# exceptions need to be made for some libraries which only ship sdists, these
+# libraries are explicitly named in --no-binary to allow for installation from
+# sdist.
 RUN mkdir -p "/home/${NB_USER}/.local" && \
     cp /requirements.txt "/home/${NB_USER}/.local/requirements.txt" && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
@@ -25,7 +34,12 @@ RUN mkdir -p "/home/${NB_USER}/.local" && \
         --generate-hashes \
         --output-file "/home/${NB_USER}/.local/requirements.lock" \
         "/home/${NB_USER}/.local/requirements.txt" && \
-    python -m pip --no-cache-dir install --requirement "/home/${NB_USER}/.local/requirements.lock" && \
+    python -m pip --no-cache-dir install \
+        --no-deps \
+        --require-hashes \
+        --only-binary :all: \
+        --no-binary termcolor,jax \
+        --requirement "/home/${NB_USER}/.local/requirements.lock" && \
     conda clean --all -f -y && \
     jupyter lab clean -y && \
     fix-permissions "${CONDA_DIR}" && \


### PR DESCRIPTION
Use Brett Cannon's recommendations for [`pip-secure-install`](https://github.com/brettcannon/pip-secure-install) to ensure that the environment is fully reproducible and can be installed as securely as possible. This works well with `pip-tools`!

c.f.:
* https://www.python.org/dev/peps/pep-0665/#secure-by-design
* https://github.com/brettcannon/pip-secure-install
* https://twitter.com/brettsky/status/1486137764315688961

The [options used to follow `pip-secure-install` recommendations](https://github.com/brettcannon/pip-secure-install/blob/92f400e3191171c1858cc0e0d9ac6320173fdb0c/README.md?plain=1#L19-L29) are:

* A requirements file must be specified to make sure all dependencies are known statically for auditing purposes (`--requirement`).
* No dependency resolution is done to make sure the requirements file is complete (`--no-deps`).
* All requirements must have a hash provided to make sure the files have not been tampered with (`--require-hashes`).
* Only wheels are allowed to have reproducible installs (`--only-binary :all:`).

In the case of the libraries `termcolor` and `jax`, which only ship sdists, the `--only-binary` option will fail and so the `--no-binary` option needs to be given explicitly for them.