### PR TITLE
fix: Add `mls` library from GitHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: image
 
 defualt: image
 
-BASE_IMAGE="jupyter/minimal-notebook:latest"
+BASE_IMAGE="jupyter/minimal-notebook:lab-3.2.8"
 
 image:
 	docker pull $(BASE_IMAGE)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ COPY docker/requirements.txt /requirements.txt
 # sdist.
 RUN mkdir -p "/home/${NB_USER}/.local" && \
     cp /requirements.txt "/home/${NB_USER}/.local/requirements.txt" && \
-    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install --upgrade 'pip<22.0' setuptools wheel && \
     python -m pip --no-cache-dir install pip-tools && \
     python -m piptools compile \
         --generate-hashes \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=jupyter/minimal-notebook:latest
+ARG BASE_IMAGE=jupyter/minimal-notebook:lab-3.2.8
 FROM ${BASE_IMAGE} as base
 
 USER root

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -15,7 +15,7 @@ awkward~=1.7.0
 hist~=2.5.2
 vector~=0.8.4
 # course specific
-git+https://github.com/dkirkby/MachineLearningStatistics/archive/3aa7385e1fd0b1572013bdf1f1c823806b744b2d.zip#egg=mls
+https://github.com/dkirkby/MachineLearningStatistics/archive/3aa7385e1fd0b1572013bdf1f1c823806b744b2d.zip#egg=mls
 emcee~=3.1.1  # required by mls
 # jupyter
 # jupyter and jupyterlab provided by the base image

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -15,7 +15,7 @@ awkward~=1.7.0
 hist~=2.5.2
 vector~=0.8.4
 # course specific
-git+https://github.com/dkirkby/MachineLearningStatistics@3aa7385e1fd0b1572013bdf1f1c823806b744b2d#egg=mls
+git+https://github.com/dkirkby/MachineLearningStatistics/archive/3aa7385e1fd0b1572013bdf1f1c823806b744b2d.zip#egg=mls
 emcee~=3.1.1  # required by mls
 # jupyter
 # jupyter and jupyterlab provided by the base image

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -15,6 +15,8 @@ hist~=2.5.2
 vector~=0.8.4
 # course specific
 git+https://github.com/dkirkby/MachineLearningStatistics@3aa7385e1fd0b1572013bdf1f1c823806b744b2d#egg=mls
+emcee~=3.1.1  # required by mls
+tables~=3.7.0  # required by mls
 # jupyter
 # jupyter and jupyterlab provided by the base image
 jupyterlab-widgets~=1.0.2

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -13,6 +13,8 @@ uproot~=4.1.9
 awkward~=1.7.0
 hist~=2.5.2
 vector~=0.8.4
+# course specific
+git+https://github.com/dkirkby/MachineLearningStatistics@3aa7385e1fd0b1572013bdf1f1c823806b744b2d#egg=mls
 # jupyter
 # jupyter and jupyterlab provided by the base image
 jupyterlab-widgets~=1.0.2

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,7 @@
 # pydata tooling
 scipy~=1.7.3
 pandas~=1.3.5
+tables~=3.7.0  # required by pandas.read_hdf
 seaborn~=0.11.2
 # machine learning
 scikit-learn~=1.0.2
@@ -16,7 +17,6 @@ vector~=0.8.4
 # course specific
 git+https://github.com/dkirkby/MachineLearningStatistics@3aa7385e1fd0b1572013bdf1f1c823806b744b2d#egg=mls
 emcee~=3.1.1  # required by mls
-tables~=3.7.0  # required by mls
 # jupyter
 # jupyter and jupyterlab provided by the base image
 jupyterlab-widgets~=1.0.2


### PR DESCRIPTION
```
* Add mls library from GitHub to allow for helper utilities like locate_data
   - Use hashable URL for piptools to generate hashes (of the form
     https://github.com/<repo org>/<repo name>/archive/<commit hash>.zip)
   - Add emcee as required by mls
* Add tables as required by pandas.read_hdf()
* Use stable base image tag jupyter/minimal-notebook:lab-3.2.8
* Restrict pip<22.0 given pip-tools bug https://github.com/jazzband/pip-tools/issues/1558
```