### PR TITLE
fix: Pin seaborn to v0.10.1 for API stability

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@
 scipy~=1.7.3
 pandas~=1.3.5
 tables~=3.7.0  # required by pandas.read_hdf
-seaborn~=0.11.2
+seaborn==0.10.1  # pinned below v0.11.0 given Dimensionality.ipynb lecture
 # machine learning
 scikit-learn~=1.0.2
 tensorflow~=2.7.0


### PR DESCRIPTION
* Resolves #10
* Resolves https://github.com/PrairieLearn/pl-phys398mla/issues/2