### PR TITLE
chore: Require pip-tools v6.5.0+ for compatibility with pip v22.0+

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ COPY docker/requirements.txt /requirements.txt
 RUN mkdir -p "/home/${NB_USER}/.local" && \
     cp /requirements.txt "/home/${NB_USER}/.local/requirements.txt" && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install 'pip-tools>6.4.0' && \
+    python -m pip --no-cache-dir install 'pip-tools>=6.5.0' && \
     python -m piptools compile \
         --generate-hashes \
         --output-file "/home/${NB_USER}/.local/requirements.lock" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ COPY docker/requirements.txt /requirements.txt
 RUN mkdir -p "/home/${NB_USER}/.local" && \
     cp /requirements.txt "/home/${NB_USER}/.local/requirements.txt" && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install pip-tools && \
+    python -m pip --no-cache-dir install 'pip-tools>6.4.0' && \
     python -m piptools compile \
         --generate-hashes \
         --output-file "/home/${NB_USER}/.local/requirements.lock" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ COPY docker/requirements.txt /requirements.txt
 # sdist.
 RUN mkdir -p "/home/${NB_USER}/.local" && \
     cp /requirements.txt "/home/${NB_USER}/.local/requirements.txt" && \
-    python -m pip --no-cache-dir install --upgrade 'pip<22.0' setuptools wheel && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install pip-tools && \
     python -m piptools compile \
         --generate-hashes \


### PR DESCRIPTION
```
* Require pip-tools>=6.5.0 to ensure compatibility with pip v22.0+
* Remove restrictions on pip
```